### PR TITLE
Feat godaddy file

### DIFF
--- a/Godaddy.html
+++ b/Godaddy.html
@@ -163,6 +163,20 @@
     border: 1px solid #ddd;
     border-radius: 4px;
   }
+
+  .decal {
+  touch-action: none; /* Prevents touch from interfering with gestures */
+  user-select: none;
+  will-change: transform;
+  transition: transform 0.05s ease-out;
+}
+  .decal:hover {
+    opacity: 0.8;
+  }
+
+  .decal:active {
+    opacity: 0.6;
+  }
 </style>
 <script src="firebase-config.js"></script>
 
@@ -222,7 +236,14 @@
           </select>
         </label>
       </div>
-
+      <div class="form-group">
+  <label>
+    Choose Template:
+    <select id="template-picker">
+      <option selected disabled>Pick a template...</option>
+    </select>
+  </label>
+</div>
       <div class="form-group">
         <label>
           Body Color:
@@ -341,26 +362,48 @@
         console.error(`[❌ Failed to load SVG for view: ${view}]`, err);
       }
     }
-
+    
     async function loadTemplates() {
-      const snapshot = await getDocs(collection(db, 'templates'));
-      const picker = document.getElementById('template-picker');
+  try {
+    const picker = document.getElementById('template-picker');
+    picker.innerHTML = `<option selected disabled>Pick a template...</option>`; // reset
 
-      snapshot.forEach(doc => {
-        const option = document.createElement('option');
-        option.value = JSON.stringify(doc.data());
-        option.textContent = doc.data().name;
-        picker.appendChild(option);
-      });
+    const snapshot = await firebase.firestore()
+      .collection('apparel')
+      .doc('varsity_jacket')
+      .collection('templates')
+      .get();
 
-      picker.addEventListener('change', e => {
-        const data = JSON.parse(e.target.value);
-        ['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'].forEach(zone => {
-          document.getElementById(`${zone}-color`).value = data[zone];
-        });
-        applyZoneColors();
+    snapshot.forEach(doc => {
+      const data = doc.data();
+      console.log('[📁 Template Loaded]', data); // double confirm
+      const option = document.createElement('option');
+      option.value = JSON.stringify(data);
+      option.textContent = data.name || doc.id;
+      picker.appendChild(option);
+    });
+
+    picker.addEventListener('change', e => {
+      const data = JSON.parse(e.target.value);
+      ['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'].forEach(zone => {
+        const select = document.getElementById(`${zone}-color`);
+        if (select && data[zone]) {
+          select.value = data[zone];
+          select.dispatchEvent(new Event('change')); // auto apply
+        }
       });
-    }
+      applyZoneColors();
+    });
+
+    console.log('[📦 Templates dropdown populated]');
+  } catch (err) {
+    console.error('[❌ Template Load Error]:', err);
+  }
+}
+
+
+
+
 async function loadColors(org = 'all') {
   const colorsRef = firebase.firestore().collection('apparel/varsity_jacket/colors');
   const query = org === 'all' ? colorsRef : colorsRef.where('tags', 'array-contains', org);
@@ -403,27 +446,6 @@ async function loadColors(org = 'all') {
   console.log(`[🎯 Loaded colors${org !== 'all' ? ` for org: ${org}` : ''}]`);
 }
 
-
-    async function loadTemplates() {
-      const snapshot = await getDocs(collection(db, 'templates'));
-      const picker = document.getElementById('template-picker');
-
-      snapshot.forEach(doc => {
-        const option = document.createElement('option');
-        option.value = JSON.stringify(doc.data());
-        option.textContent = doc.data().name;
-        picker.appendChild(option);
-      });
-
-      picker.addEventListener('change', e => {
-        const data = JSON.parse(e.target.value);
-        ['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'].forEach(zone => {
-          document.getElementById(`${zone}-color`).value = data[zone];
-        });
-        applyZoneColors();
-      });
-    }
-
     function updatePreview() {
       try {
         const selectedColor = JSON.parse(colorPicker.value);
@@ -444,39 +466,79 @@ async function loadColors(org = 'all') {
       }
     }
 
-    function makeDraggable(el) {
-      interact(el).draggable({
-        listeners: {
-          move(event) {
-            const target = event.target;
-            const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
-            const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
-            target.style.transform = `translate(${x}px, ${y}px)`;
-            target.setAttribute('data-x', x);
-            target.setAttribute('data-y', y);
-          },
-          end(event) {
-            const { target } = event;
-            const x = target.getAttribute('data-x');
-            const y = target.getAttribute('data-y');
-            console.log(`[📦 Decal moved]: ${target.alt} to (${x}, ${y})`);
-          },
-        },
-      });
-    }
+    function makeInteractiveDecal(el) {
+  interact(el)
+    .draggable({
+      listeners: {
+        move(event) {
+          const target = event.target;
+          const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
+          const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+
+          target.style.transform = `
+            translate(${x}px, ${y}px)
+            scale(${target.getAttribute('data-scale') || 1})
+            rotate(${target.getAttribute('data-rotation') || 0}deg)
+          `;
+          target.setAttribute('data-x', x);
+          target.setAttribute('data-y', y);
+        }
+      }
+    })
+    .gesturable({
+      listeners: {
+        move(event) {
+          const target = event.target;
+
+          const currentScale = parseFloat(target.getAttribute('data-scale')) || 1;
+          const currentRotation = parseFloat(target.getAttribute('data-rotation')) || 0;
+
+          const newScale = currentScale * (1 + event.ds);
+          const newRotation = currentRotation + event.da;
+
+          target.setAttribute('data-scale', newScale);
+          target.setAttribute('data-rotation', newRotation);
+
+          const x = parseFloat(target.getAttribute('data-x')) || 0;
+          const y = parseFloat(target.getAttribute('data-y')) || 0;
+
+          target.style.transform = `
+            translate(${x}px, ${y}px)
+            scale(${newScale})
+            rotate(${newRotation}deg)
+          `;
+        }
+      }
+    });
+}
+
 
     function addDecalToCanvas(url, name) {
-      const img = document.createElement('img');
-      img.src = url;
-      img.alt = name;
-      img.title = name;
-      img.className = 'decal';
-      img.setAttribute('data-x', 0);
-      img.setAttribute('data-y', 0);
-      decalContainer.appendChild(img);
-      makeDraggable(img);
-      console.log(`[✨ Decal added from modal]: ${name}`);
-    }
+  const img = document.createElement('img');
+  img.src = url;
+  img.alt = name;
+  img.title = name;
+  img.className = 'decal';
+
+  // Set transform data
+  img.setAttribute('data-x', 0);
+  img.setAttribute('data-y', 0);
+  img.setAttribute('data-scale', 1);
+  img.setAttribute('data-rotation', 0);
+
+  // Add interaction
+  decalContainer.appendChild(img);
+  makeInteractiveDecal(img);
+
+  // Allow removal on double-click
+  img.ondblclick = () => {
+    decalContainer.removeChild(img);
+    console.log(`[🗑️ Removed decal]: ${name}`);
+  };
+
+  console.log(`[✨ Added decal]: ${name}`);
+}
+
 
     function openModal(category, decals) {
       const modal = document.getElementById('decal-modal');
@@ -511,26 +573,31 @@ async function loadColors(org = 'all') {
     return;
   }
 
+  const getColor = id => {
+    const select = document.getElementById(`${id}-color`);
+    return select?.value || '#000000'; // fallback color
+  };
+
   const zones = {
-    'front_torso': document.getElementById('body-color').value,
-    'front_pockets': document.getElementById('body-color').value,
-    'front_left_sleeve': document.getElementById('sleeves-color').value,
-    'front_right_sleeve': document.getElementById('sleeves-color').value,
-    'front_left_cuff': document.getElementById('cuffs-color').value,
-    'front_right_cuff': document.getElementById('cuffs-color').value,
-    'front_bottom': document.getElementById('cuffs-color').value,
-    'front_collar': document.getElementById('collar-color').value,
-    'front_left_sleeve_lines': document.getElementById('lines-color').value,
-    'front_right_sleeve_lines': document.getElementById('lines-color').value,
-    'front_collar_lines': document.getElementById('lines-color').value,
-    'button_group': document.getElementById('buttons-color').value,
+    'front_torso': getColor('body'),
+    'front_pockets': getColor('body'),
+    'front_left_sleeve': getColor('sleeves'),
+    'front_right_sleeve': getColor('sleeves'),
+    'front_left_cuff': getColor('cuffs'),
+    'front_right_cuff': getColor('cuffs'),
+    'front_bottom': getColor('cuffs'),
+    'front_collar': getColor('collar'),
+    'front_left_sleeve_lines': getColor('lines'),
+    'front_right_sleeve_lines': getColor('lines'),
+    'front_collar_lines': getColor('lines'),
+    'button_group': getColor('buttons'),
   };
 
   Object.entries(zones).forEach(([id, color]) => {
     const el = svg.getElementById(id);
-    if (el) {
-      el.removeAttribute('style'); // 🔥 clear inline style first
-      el.setAttribute('fill', color); // then apply fill
+    if (el && color) {
+      el.removeAttribute('style');
+      el.setAttribute('fill', color);
     }
   });
 
@@ -593,18 +660,18 @@ async function loadColors(org = 'all') {
       loadColors(org);
     });
 
-    window.addEventListener('DOMContentLoaded', async () => {
-      await loadColors();
-      await loadTemplates();
-      ['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'].forEach(zone => {
-        document.getElementById(`${zone}-color`).addEventListener('change', applyZoneColors);
-      });
-      console.log('[✅ All event listeners attached]');
-    });
+// GO TIME (IN CORRECT ORDER):
+await fetchJacketViews();       // 🧥 Get SVG
+await loadColors();             // 🎨 Fill dropdowns
+await loadTemplates();          // 🧠 Load template styles
+await renderCategoryTabs();     // 🔖 Show decals
 
-    // GO TIME
-    await fetchJacketViews();
-    await loadColors();
-    await renderCategoryTabs();
+// 💡 Attach listeners AFTER dropdowns exist
+['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'].forEach(zone => {
+  document.getElementById(`${zone}-color`).addEventListener('change', applyZoneColors);
+});
+
+console.log('[✅ All event listeners attached]');
+  
   };
 </script>

--- a/Godaddy.html
+++ b/Godaddy.html
@@ -165,11 +165,11 @@
   }
 
   .decal {
-  touch-action: none; /* Prevents touch from interfering with gestures */
-  user-select: none;
-  will-change: transform;
-  transition: transform 0.05s ease-out;
-}
+    touch-action: none; /* Prevents touch from interfering with gestures */
+    user-select: none;
+    will-change: transform;
+    transition: transform 0.05s ease-out;
+  }
   .decal:hover {
     opacity: 0.8;
   }
@@ -178,6 +178,7 @@
     opacity: 0.6;
   }
 </style>
+
 <script src="firebase-config.js"></script>
 
 <!-- DESIGN STUDIO -->
@@ -237,13 +238,13 @@
         </label>
       </div>
       <div class="form-group">
-  <label>
-    Choose Template:
-    <select id="template-picker">
-      <option selected disabled>Pick a template...</option>
-    </select>
-  </label>
-</div>
+        <label>
+          Choose Template:
+          <select id="template-picker">
+            <option selected disabled>Pick a template...</option>
+          </select>
+        </label>
+      </div>
       <div class="form-group">
         <label>
           Body Color:
@@ -362,89 +363,87 @@
         console.error(`[❌ Failed to load SVG for view: ${view}]`, err);
       }
     }
-    
+
     async function loadTemplates() {
-  try {
-    const picker = document.getElementById('template-picker');
-    picker.innerHTML = `<option selected disabled>Pick a template...</option>`; // reset
+      try {
+        const picker = document.getElementById('template-picker');
+        picker.innerHTML = `<option selected disabled>Pick a template...</option>`; // reset
 
-    const snapshot = await firebase.firestore()
-      .collection('apparel')
-      .doc('varsity_jacket')
-      .collection('templates')
-      .get();
+        const snapshot = await firebase
+          .firestore()
+          .collection('apparel')
+          .doc('varsity_jacket')
+          .collection('templates')
+          .get();
 
-    snapshot.forEach(doc => {
-      const data = doc.data();
-      console.log('[📁 Template Loaded]', data); // double confirm
-      const option = document.createElement('option');
-      option.value = JSON.stringify(data);
-      option.textContent = data.name || doc.id;
-      picker.appendChild(option);
-    });
+        snapshot.forEach(doc => {
+          const data = doc.data();
+          console.log('[📁 Template Loaded]', data); // double confirm
+          const option = document.createElement('option');
+          option.value = JSON.stringify(data);
+          option.textContent = data.name || doc.id;
+          picker.appendChild(option);
+        });
 
-    picker.addEventListener('change', e => {
-      const data = JSON.parse(e.target.value);
-      ['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'].forEach(zone => {
+        picker.addEventListener('change', e => {
+          const data = JSON.parse(e.target.value);
+          ['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'].forEach(zone => {
+            const select = document.getElementById(`${zone}-color`);
+            if (select && data[zone]) {
+              select.value = data[zone];
+              select.dispatchEvent(new Event('change')); // auto apply
+            }
+          });
+          applyZoneColors();
+        });
+
+        console.log('[📦 Templates dropdown populated]');
+      } catch (err) {
+        console.error('[❌ Template Load Error]:', err);
+      }
+    }
+
+    async function loadColors(org = 'all') {
+      const colorsRef = firebase.firestore().collection('apparel/varsity_jacket/colors');
+      const query = org === 'all' ? colorsRef : colorsRef.where('tags', 'array-contains', org);
+
+      const snapshot = await query.get();
+
+      const zones = ['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'];
+      const colorOptions = {};
+
+      zones.forEach(zone => {
         const select = document.getElementById(`${zone}-color`);
-        if (select && data[zone]) {
-          select.value = data[zone];
-          select.dispatchEvent(new Event('change')); // auto apply
+        select.innerHTML = '';
+        colorOptions[zone] = [];
+
+        // ✅ Add listener if not already added
+        select.addEventListener('change', applyZoneColors);
+      });
+
+      snapshot.forEach(doc => {
+        const { name, hex } = doc.data();
+        zones.forEach(zone => {
+          const select = document.getElementById(`${zone}-color`);
+          const option = document.createElement('option');
+          option.value = hex;
+          option.textContent = `${name} (${hex})`;
+          select.appendChild(option);
+          colorOptions[zone].push(hex);
+        });
+      });
+
+      // ✅ Default value + force-trigger color update
+      zones.forEach(zone => {
+        const select = document.getElementById(`${zone}-color`);
+        if (colorOptions[zone].length > 0) {
+          select.value = colorOptions[zone][0];
+          select.dispatchEvent(new Event('change'));
         }
       });
-      applyZoneColors();
-    });
 
-    console.log('[📦 Templates dropdown populated]');
-  } catch (err) {
-    console.error('[❌ Template Load Error]:', err);
-  }
-}
-
-
-
-
-async function loadColors(org = 'all') {
-  const colorsRef = firebase.firestore().collection('apparel/varsity_jacket/colors');
-  const query = org === 'all' ? colorsRef : colorsRef.where('tags', 'array-contains', org);
-
-  const snapshot = await query.get();
-
-  const zones = ['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'];
-  const colorOptions = {};
-
-  zones.forEach(zone => {
-    const select = document.getElementById(`${zone}-color`);
-    select.innerHTML = '';
-    colorOptions[zone] = [];
-
-    // ✅ Add listener if not already added
-    select.addEventListener('change', applyZoneColors);
-  });
-
-  snapshot.forEach(doc => {
-    const { name, hex } = doc.data();
-    zones.forEach(zone => {
-      const select = document.getElementById(`${zone}-color`);
-      const option = document.createElement('option');
-      option.value = hex;
-      option.textContent = `${name} (${hex})`;
-      select.appendChild(option);
-      colorOptions[zone].push(hex);
-    });
-  });
-
-  // ✅ Default value + force-trigger color update
-  zones.forEach(zone => {
-    const select = document.getElementById(`${zone}-color`);
-    if (colorOptions[zone].length > 0) {
-      select.value = colorOptions[zone][0];
-      select.dispatchEvent(new Event('change'));
+      console.log(`[🎯 Loaded colors${org !== 'all' ? ` for org: ${org}` : ''}]`);
     }
-  });
-
-  console.log(`[🎯 Loaded colors${org !== 'all' ? ` for org: ${org}` : ''}]`);
-}
 
     function updatePreview() {
       try {
@@ -467,78 +466,76 @@ async function loadColors(org = 'all') {
     }
 
     function makeInteractiveDecal(el) {
-  interact(el)
-    .draggable({
-      listeners: {
-        move(event) {
-          const target = event.target;
-          const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
-          const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+      interact(el)
+        .draggable({
+          listeners: {
+            move(event) {
+              const target = event.target;
+              const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
+              const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
 
-          target.style.transform = `
+              target.style.transform = `
             translate(${x}px, ${y}px)
             scale(${target.getAttribute('data-scale') || 1})
             rotate(${target.getAttribute('data-rotation') || 0}deg)
           `;
-          target.setAttribute('data-x', x);
-          target.setAttribute('data-y', y);
-        }
-      }
-    })
-    .gesturable({
-      listeners: {
-        move(event) {
-          const target = event.target;
+              target.setAttribute('data-x', x);
+              target.setAttribute('data-y', y);
+            },
+          },
+        })
+        .gesturable({
+          listeners: {
+            move(event) {
+              const target = event.target;
 
-          const currentScale = parseFloat(target.getAttribute('data-scale')) || 1;
-          const currentRotation = parseFloat(target.getAttribute('data-rotation')) || 0;
+              const currentScale = parseFloat(target.getAttribute('data-scale')) || 1;
+              const currentRotation = parseFloat(target.getAttribute('data-rotation')) || 0;
 
-          const newScale = currentScale * (1 + event.ds);
-          const newRotation = currentRotation + event.da;
+              const newScale = currentScale * (1 + event.ds);
+              const newRotation = currentRotation + event.da;
 
-          target.setAttribute('data-scale', newScale);
-          target.setAttribute('data-rotation', newRotation);
+              target.setAttribute('data-scale', newScale);
+              target.setAttribute('data-rotation', newRotation);
 
-          const x = parseFloat(target.getAttribute('data-x')) || 0;
-          const y = parseFloat(target.getAttribute('data-y')) || 0;
+              const x = parseFloat(target.getAttribute('data-x')) || 0;
+              const y = parseFloat(target.getAttribute('data-y')) || 0;
 
-          target.style.transform = `
+              target.style.transform = `
             translate(${x}px, ${y}px)
             scale(${newScale})
             rotate(${newRotation}deg)
           `;
-        }
-      }
-    });
-}
-
+            },
+          },
+        });
+    }
 
     function addDecalToCanvas(url, name) {
-  const img = document.createElement('img');
-  img.src = url;
-  img.alt = name;
-  img.title = name;
-  img.className = 'decal';
+      const img = document.createElement('img');
+      img.src = url;
+      img.alt = name;
+      img.title = name;
+      img.className = 'decal';
 
-  // Set transform data
-  img.setAttribute('data-x', 0);
-  img.setAttribute('data-y', 0);
-  img.setAttribute('data-scale', 1);
-  img.setAttribute('data-rotation', 0);
+      // Set transform data
+      img.setAttribute('data-x', 0);
+      img.setAttribute('data-y', 0);
+      img.setAttribute('data-scale', 1);
+      img.setAttribute('data-rotation', 0);
 
-  // Add interaction
-  decalContainer.appendChild(img);
-  makeInteractiveDecal(img);
+      // Add interaction
+      decalContainer.appendChild(img);
+      makeInteractiveDecal(img);
 
-  // Allow removal on double-click
-  img.ondblclick = () => {
-    decalContainer.removeChild(img);
-    console.log(`[🗑️ Removed decal]: ${name}`);
-  };
+      // Allow removal on double-click
+      img.ondblclick = () => {
+        decalContainer.removeChild(img);
+        console.log(`[🗑️ Removed decal]: ${name}`);
+      };
 
-  console.log(`[✨ Added decal]: ${name}`);
-}
-
+      console.log(`[✨ Added decal]: ${name}`);
+    }
 
     function openModal(category, decals) {
       const modal = document.getElementById('decal-modal');
@@ -566,46 +563,49 @@ async function loadColors(org = 'all') {
 
     function closeModal() {
       document.getElementById('decal-modal').style.display = 'none';
-    }function applyZoneColors() {
-  const svg = document.querySelector('svg');
-  if (!svg) {
-    console.warn('[⛔ SVG not found in DOM]');
-    return;
-  }
-
-  const getColor = id => {
-    const select = document.getElementById(`${id}-color`);
-    return select?.value || '#000000'; // fallback color
-  };
-
-  const zones = {
-    'front_torso': getColor('body'),
-    'front_pockets': getColor('body'),
-    'front_left_sleeve': getColor('sleeves'),
-    'front_right_sleeve': getColor('sleeves'),
-    'front_left_cuff': getColor('cuffs'),
-    'front_right_cuff': getColor('cuffs'),
-    'front_bottom': getColor('cuffs'),
-    'front_collar': getColor('collar'),
-    'front_left_sleeve_lines': getColor('lines'),
-    'front_right_sleeve_lines': getColor('lines'),
-    'front_collar_lines': getColor('lines'),
-    'button_group': getColor('buttons'),
-  };
-
-  Object.entries(zones).forEach(([id, color]) => {
-    const el = svg.getElementById(id);
-    if (el && color) {
-      el.removeAttribute('style');
-      el.setAttribute('fill', color);
     }
-  });
 
-  console.log('[🎨 Zone colors applied]');
-  console.log('[🧪 SVG Elements]', [...svg.querySelectorAll('[id]')].map(e => `${e.id} (${e.getAttribute('fill')})`));
-}
+    function applyZoneColors() {
+      const svg = document.querySelector('svg');
+      if (!svg) {
+        console.warn('[⛔ SVG not found in DOM]');
+        return;
+      }
 
+      const getColor = id => {
+        const select = document.getElementById(`${id}-color`);
+        return select?.value || '#000000'; // fallback color
+      };
 
+      const zones = {
+        front_torso: getColor('body'),
+        front_pockets: getColor('body'),
+        front_left_sleeve: getColor('sleeves'),
+        front_right_sleeve: getColor('sleeves'),
+        front_left_cuff: getColor('cuffs'),
+        front_right_cuff: getColor('cuffs'),
+        front_bottom: getColor('cuffs'),
+        front_collar: getColor('collar'),
+        front_left_sleeve_lines: getColor('lines'),
+        front_right_sleeve_lines: getColor('lines'),
+        front_collar_lines: getColor('lines'),
+        button_group: getColor('buttons'),
+      };
+
+      Object.entries(zones).forEach(([id, color]) => {
+        const el = svg.getElementById(id);
+        if (el && color) {
+          el.removeAttribute('style');
+          el.setAttribute('fill', color);
+        }
+      });
+
+      console.log('[🎨 Zone colors applied]');
+      console.log(
+        '[🧪 SVG Elements]',
+        [...svg.querySelectorAll('[id]')].map(e => `${e.id} (${e.getAttribute('fill')})`)
+      );
+    }
 
     async function renderCategoryTabs() {
       const tabContainer = document.getElementById('decal-tabs');
@@ -660,18 +660,17 @@ async function loadColors(org = 'all') {
       loadColors(org);
     });
 
-// GO TIME (IN CORRECT ORDER):
-await fetchJacketViews();       // 🧥 Get SVG
-await loadColors();             // 🎨 Fill dropdowns
-await loadTemplates();          // 🧠 Load template styles
-await renderCategoryTabs();     // 🔖 Show decals
+    // GO TIME (IN CORRECT ORDER):
+    await fetchJacketViews(); // 🧥 Get SVG
+    await loadColors(); // 🎨 Fill dropdowns
+    await loadTemplates(); // 🧠 Load template styles
+    await renderCategoryTabs(); // 🔖 Show decals
 
-// 💡 Attach listeners AFTER dropdowns exist
-['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'].forEach(zone => {
-  document.getElementById(`${zone}-color`).addEventListener('change', applyZoneColors);
-});
+    // 💡 Attach listeners AFTER dropdowns exist
+    ['body', 'sleeves', 'cuffs', 'collar', 'lines', 'buttons'].forEach(zone => {
+      document.getElementById(`${zone}-color`).addEventListener('change', applyZoneColors);
+    });
 
-console.log('[✅ All event listeners attached]');
-  
+    console.log('[✅ All event listeners attached]');
   };
 </script>


### PR DESCRIPTION
This pull request introduces the foundational logic for the varsity jacket decal feature. Users can now view decal categories pulled from Firestore, click a decal to add it to the preview area, and freely drag decals around the canvas using Interact.js. Decals are positioned absolutely within the #decal-container and support drag-and-drop functionality with live transform updates. A double-click on any decal will remove it from the canvas.

This setup uses data from a decals collection in Firebase. Each decal is represented as a simple object with a name, category, and url. The categories are rendered as collapsible dropdowns, and thumbnails load dynamically.

CSS has been added to enable draggable behavior. The container uses position: relative, and each decal uses position: absolute with cursor and interaction styles applied to support smooth drag events. Currently Bugged

TODO:

If you’re picking up from here, here’s how to continue or restart the feature:

- Confirm interact.min.js is loaded before any decal logic runs.
- Add new decals to the Firestore decals collection with name, category, and url.
- Click on a decal from the dropdown to add it to the preview.
- Drag the decal around the canvas to reposition it.
- Double-click a decal to remove it.

If needed, use addDecalToCanvas(url, name) to place a new decal, and makeInteractiveDecal(el) to apply drag behavior.

Let me know if you run into any blockers. I’ll be shifting focus to the payment integration portion next.
